### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
 
@@ -17,4 +21,8 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      composer-dependencies:
+        patterns:
+          - "*"
     versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Replicates the Dependabot grouping configuration from yiisoft/package-template so GitHub Actions updates are grouped into a single PR and Composer dependency updates are grouped into a single PR.